### PR TITLE
fix: eviter la navigation dans le vide

### DIFF
--- a/lib/app_initializer.dart
+++ b/lib/app_initializer.dart
@@ -191,7 +191,7 @@ class AppInitializer {
       securedPreferences,
       crashlytics,
     );
-    final accessTokenRetriever = AuthAccessTokenRetriever(authenticator, remoteConfigRepository, Lock());
+    final accessTokenRetriever = AuthAccessTokenRetriever(authenticator, remoteConfigRepository, securedPreferences, Lock());
     final authAccessChecker = AuthAccessChecker();
     final cacheStore = FileCacheStore((await getTemporaryDirectory()).path);
     final requestCacheManager = PassEmploiCacheManager(cacheStore, configuration.serverBaseUrl);

--- a/lib/auth/auth_access_token_retriever.dart
+++ b/lib/auth/auth_access_token_retriever.dart
@@ -1,19 +1,28 @@
-import 'package:pass_emploi_app/auth/auth_id_token.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:pass_emploi_app/auth/authenticator.dart';
 import 'package:pass_emploi_app/features/login/login_actions.dart';
-import 'package:pass_emploi_app/models/login_mode.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
 import 'package:pass_emploi_app/repositories/remote_config_repository.dart';
 import 'package:redux/redux.dart';
 import 'package:synchronized/synchronized.dart';
 
 class AuthAccessTokenRetriever {
+  static const _failureCountKey = 'consecutiveRefreshGenericErrors';
+
   final Authenticator _authenticator;
   final RemoteConfigRepository _remoteConfigRepository;
+  final FlutterSecureStorage _preferences;
   final Lock _lock;
   late Store<AppState> _store;
+  
+  int? _cachedFailureCount;
 
-  AuthAccessTokenRetriever(this._authenticator, this._remoteConfigRepository, this._lock);
+  AuthAccessTokenRetriever(
+    this._authenticator,
+    this._remoteConfigRepository,
+    this._preferences,
+    this._lock,
+  );
 
   Future<String> accessToken() async {
     return _lock.synchronized(() async => _accessToken());
@@ -23,25 +32,56 @@ class AuthAccessTokenRetriever {
     final accessToken = await _authenticator.idToken();
     if (accessToken == null) throw Exception("ID Token is null");
 
-    if (accessToken.isValid(now: DateTime.now(), maxLivingTimeInSeconds: maxLivingTimeInSeconds(accessToken))) {
+    if (accessToken.isValid(now: DateTime.now())) {
+      await _resetFailureCount();
       return (await _authenticator.accessToken())!;
     }
 
     final refreshTokenStatus = await _authenticator.performRefreshToken();
     switch (refreshTokenStatus) {
       case RefreshTokenStatus.SUCCESSFUL:
+        await _resetFailureCount();
         return (await _authenticator.accessToken())!;
+      case RefreshTokenStatus.NETWORK_UNREACHABLE:
+        throw Exception(
+          "Token refresh failed (network error): $refreshTokenStatus",
+        );
+      case RefreshTokenStatus.GENERIC_ERROR:
+       final count = await _incrementFailureCount();
+        _store.dispatch(TokenRefreshGenericErrorAction(count));
+        if (count >= _remoteConfigRepository.maxRefreshFailuresBeforeLogout()) {
+          await _resetFailureCount();
+          _store.dispatch(
+            RequestLogoutAction(LogoutReason.tooManyRefreshGenericErrors),
+          );
+        }
+        throw Exception(
+          "Token refresh failed (generic error): $refreshTokenStatus",
+        );
       case RefreshTokenStatus.EXPIRED_REFRESH_TOKEN:
+      case RefreshTokenStatus.USER_NOT_LOGGED_IN:
+        await _resetFailureCount();
         _store.dispatch(RequestLogoutAction(LogoutReason.expiredRefreshToken));
-        throw Exception("Refresh token is expired");
-      default:
-        throw Exception(refreshTokenStatus);
+        throw Exception("Cannot refresh token: $refreshTokenStatus");
     }
   }
 
-  int? maxLivingTimeInSeconds(AuthIdToken idToken) {
-    if (idToken.getLoginMode().isMiLo()) return _remoteConfigRepository.maxLivingTimeInSecondsForMilo();
-    return null;
+  Future<int> _failureCount() async {
+    return _cachedFailureCount ??=
+        int.tryParse(await _preferences.read(key: _failureCountKey) ?? '') ?? 0;
+  }
+
+  Future<int> _incrementFailureCount() async {
+    final next = (await _failureCount()) + 1;
+    _cachedFailureCount = next;
+    await _preferences.write(key: _failureCountKey, value: next.toString());
+    return next;
+  }
+
+  Future<void> _resetFailureCount() async {
+    if ((await _failureCount()) == 0) return;
+    _cachedFailureCount = 0;
+    await _preferences.delete(key: _failureCountKey);
   }
 
   void setStore(Store<AppState> store) => _store = store;

--- a/lib/auth/auth_access_token_retriever.dart
+++ b/lib/auth/auth_access_token_retriever.dart
@@ -14,7 +14,6 @@ class AuthAccessTokenRetriever {
   final FlutterSecureStorage _preferences;
   final Lock _lock;
   late Store<AppState> _store;
-  
   int? _cachedFailureCount;
 
   AuthAccessTokenRetriever(
@@ -47,7 +46,7 @@ class AuthAccessTokenRetriever {
           "Token refresh failed (network error): $refreshTokenStatus",
         );
       case RefreshTokenStatus.GENERIC_ERROR:
-       final count = await _incrementFailureCount();
+        final count = await _incrementFailureCount();
         _store.dispatch(TokenRefreshGenericErrorAction(count));
         if (count >= _remoteConfigRepository.maxRefreshFailuresBeforeLogout()) {
           await _resetFailureCount();

--- a/lib/auth/auth_id_token.dart
+++ b/lib/auth/auth_id_token.dart
@@ -49,16 +49,7 @@ class AuthIdToken extends Equatable {
     );
   }
 
-  bool isValid({required DateTime now, int? maxLivingTimeInSeconds}) {
-    return isValidBasedOnExpirationDate(now) && isValidBasedOnMaxLivingTime(now, maxLivingTimeInSeconds);
-  }
-
-  bool isValidBasedOnMaxLivingTime(DateTime now, int? maxLivingTimeInSeconds) {
-    if (maxLivingTimeInSeconds == null) return true;
-    return now.isStillValidWith(expirationDateInSeconds: issuedAt + maxLivingTimeInSeconds);
-  }
-
-  bool isValidBasedOnExpirationDate(DateTime now) => now.isStillValidWith(expirationDateInSeconds: expiresAt);
+  bool isValid({required DateTime now}) => now.isStillValidWith(expirationDateInSeconds: expiresAt);
 
   @override
   List<Object?> get props => [userId, firstName, lastName, issuedAt, expiresAt];

--- a/lib/auth/authenticator.dart
+++ b/lib/auth/authenticator.dart
@@ -41,7 +41,7 @@ class Authenticator {
   final FlutterSecureStorage _preferences;
   final Crashlytics? _crashlytics;
 
-  Authenticator(this._authWrapper, this._logoutRepository, this._configuration, this._preferences, [this._crashlytics]);
+Authenticator(this._authWrapper, this._logoutRepository, this._configuration, this._preferences, [this._crashlytics]);
 
   Future<AuthenticatorResponse> login(AuthenticationMode mode) async {
     try {
@@ -111,8 +111,9 @@ class Authenticator {
 
   Future<bool> logout(String userId, LogoutReason reason) async {
     final String? refreshToken = await _preferences.read(key: _refreshTokenKey);
-    if (refreshToken == null) return false;
-    await _logoutRepository.logout(refreshToken, userId, reason);
+    if (refreshToken != null) {
+      await _logoutRepository.logout(refreshToken, userId, reason);
+    }
     await _deleteToken();
     return true;
   }

--- a/lib/auth/authenticator.dart
+++ b/lib/auth/authenticator.dart
@@ -41,7 +41,7 @@ class Authenticator {
   final FlutterSecureStorage _preferences;
   final Crashlytics? _crashlytics;
 
-Authenticator(this._authWrapper, this._logoutRepository, this._configuration, this._preferences, [this._crashlytics]);
+  Authenticator(this._authWrapper, this._logoutRepository, this._configuration, this._preferences, [this._crashlytics]);
 
   Future<AuthenticatorResponse> login(AuthenticationMode mode) async {
     try {

--- a/lib/features/login/login_actions.dart
+++ b/lib/features/login/login_actions.dart
@@ -1,10 +1,28 @@
 import 'package:pass_emploi_app/models/login_mode.dart';
 import 'package:pass_emploi_app/models/user.dart';
 
-enum LogoutReason { userLogout, apiResponse401, expiredRefreshToken, accountSuppression, cguRefused, tooMany401 }
+enum LogoutReason {
+  userLogout,
+  apiResponse401,
+  expiredRefreshToken,
+  accountSuppression,
+  cguRefused,
+  tooMany401,
+  tooManyRefreshGenericErrors,
+}
 
 extension LoginModeModeExtension on LoginMode {
   bool isDemo() => this == LoginMode.DEMO_PE || this == LoginMode.DEMO_MILO;
+}
+
+class TokenRefreshGenericErrorAction {
+  final int consecutiveFailures;
+
+  TokenRefreshGenericErrorAction(this.consecutiveFailures);
+
+  @override
+  String toString() =>
+      'TokenRefreshFailedAction(consecutive: $consecutiveFailures)';
 }
 
 class LoginRequestAction {}

--- a/lib/features/tech/crashlytics_middleware.dart
+++ b/lib/features/tech/crashlytics_middleware.dart
@@ -16,11 +16,15 @@ class CrashlyticsMiddleware extends MiddlewareClass<AppState> {
 
   @override
   void call(Store<AppState> store, dynamic action, NextDispatcher next) async {
-    if (action is LoginSuccessAction)
+    if (action is LoginSuccessAction) {
       crashlytics.setUserIdentifier(action.user.id);
-    if (action is RequestLogoutAction) _trackLogout(action.reason);
-    if (action is TokenRefreshGenericErrorAction)
+    }
+    if (action is RequestLogoutAction) {
+      _trackLogout(action.reason);
+    }
+    if (action is TokenRefreshGenericErrorAction) {
       _trackTokenRefreshFailure(action);
+    }
 
     _lastActions.add(_actionToString(action));
     crashlytics.setCustomKey("last_actions", _formatQueueForCrashlytics());
@@ -80,6 +84,5 @@ class CrashlyticsMiddleware extends MiddlewareClass<AppState> {
     return _lastActions.toList().toString();
   }
 
-  String _formatStoreForCrashlytics(Store<AppState> store) =>
-      store.state.toString().replaceAll('Instance of ', '');
+  String _formatStoreForCrashlytics(Store<AppState> store) => store.state.toString().replaceAll('Instance of ', '');
 }

--- a/lib/features/tech/crashlytics_middleware.dart
+++ b/lib/features/tech/crashlytics_middleware.dart
@@ -68,6 +68,7 @@ class CrashlyticsMiddleware extends MiddlewareClass<AppState> {
       "Token refresh failed (GENERIC), consecutive: ${action.consecutiveFailures}",
     );
 
+    // On ne loggue que sur le premier échec
     if (action.consecutiveFailures == 1) {
       crashlytics.recordNonNetworkException(
         "ZombieState: app en ligne mais refresh impossible (pas de logout)",

--- a/lib/features/tech/crashlytics_middleware.dart
+++ b/lib/features/tech/crashlytics_middleware.dart
@@ -16,13 +16,60 @@ class CrashlyticsMiddleware extends MiddlewareClass<AppState> {
 
   @override
   void call(Store<AppState> store, dynamic action, NextDispatcher next) async {
-    if (action is LoginSuccessAction) crashlytics.setUserIdentifier(action.user.id);
+    if (action is LoginSuccessAction)
+      crashlytics.setUserIdentifier(action.user.id);
+    if (action is RequestLogoutAction) _trackLogout(action.reason);
+    if (action is TokenRefreshGenericErrorAction)
+      _trackTokenRefreshFailure(action);
 
     _lastActions.add(_actionToString(action));
     crashlytics.setCustomKey("last_actions", _formatQueueForCrashlytics());
     crashlytics.setCustomKey("app_state", _formatStoreForCrashlytics(store));
 
     next(action);
+  }
+
+  void _trackLogout(LogoutReason reason) {
+    crashlytics.setCustomKey("last_logout_reason", reason.name);
+    crashlytics.log("Logout: ${reason.name}");
+
+    if (_isUnexpectedLogout(reason)) {
+      crashlytics.recordNonNetworkException(
+        "Logout subi: ${reason.name}",
+        StackTrace.current,
+      );
+    }
+  }
+
+  bool _isUnexpectedLogout(LogoutReason reason) {
+    switch (reason) {
+      case LogoutReason.userLogout:
+      case LogoutReason.accountSuppression:
+      case LogoutReason.cguRefused:
+        return false;
+      case LogoutReason.apiResponse401:
+      case LogoutReason.expiredRefreshToken:
+      case LogoutReason.tooMany401:
+      case LogoutReason.tooManyRefreshGenericErrors:
+        return true;
+    }
+  }
+
+  void _trackTokenRefreshFailure(TokenRefreshGenericErrorAction action) {
+    crashlytics.setCustomKey(
+      "consecutive_refresh_failures",
+      action.consecutiveFailures.toString(),
+    );
+    crashlytics.log(
+      "Token refresh failed (GENERIC), consecutive: ${action.consecutiveFailures}",
+    );
+
+    if (action.consecutiveFailures == 1) {
+      crashlytics.recordNonNetworkException(
+        "ZombieState: app en ligne mais refresh impossible (pas de logout)",
+        StackTrace.current,
+      );
+    }
   }
 
   String _actionToString(dynamic action) {
@@ -33,5 +80,6 @@ class CrashlyticsMiddleware extends MiddlewareClass<AppState> {
     return _lastActions.toList().toString();
   }
 
-  String _formatStoreForCrashlytics(Store<AppState> store) => store.state.toString().replaceAll('Instance of ', '');
+  String _formatStoreForCrashlytics(Store<AppState> store) =>
+      store.state.toString().replaceAll('Instance of ', '');
 }

--- a/lib/repositories/remote_config_repository.dart
+++ b/lib/repositories/remote_config_repository.dart
@@ -15,9 +15,7 @@ class RemoteConfigRepository {
   int? maxLivingTimeInSecondsForMilo() {
     if (_firebaseRemoteConfig == null) return null;
 
-    final value = _firebaseRemoteConfig.getInt(
-      "app_milo_max_living_time_in_seconds",
-    );
+    final value = _firebaseRemoteConfig.getInt("app_milo_max_living_time_in_seconds");
     return value > 0 ? value : null;
   }
 
@@ -32,9 +30,7 @@ class RemoteConfigRepository {
     const defaultMax = 20;
     if (_firebaseRemoteConfig == null) return defaultMax;
 
-    final value = _firebaseRemoteConfig.getInt(
-      "app_max_refresh_failures_before_logout",
-    );
+    final value = _firebaseRemoteConfig.getInt("app_max_refresh_failures_before_logout");
     return value > 0 ? value : defaultMax;
   }
 
@@ -48,9 +44,7 @@ class RemoteConfigRepository {
 
     // millisecond since epoch
     final value = _firebaseRemoteConfig.getInt("campagne_recrutement_date_fin");
-    return value > DateTime.now().millisecondsSinceEpoch
-        ? value.toString()
-        : null;
+    return value > DateTime.now().millisecondsSinceEpoch ? value.toString() : null;
   }
 
   List<RemoteCampagneAccueil> campagnesAccueil() {
@@ -58,15 +52,11 @@ class RemoteConfigRepository {
     try {
       if (_firebaseRemoteConfig == null) return [];
 
-      final campagneAsString = _firebaseRemoteConfig.getString(
-        "campagnes_accueil",
-      );
+      final campagneAsString = _firebaseRemoteConfig.getString("campagnes_accueil");
       // Despite Remote config documentation, Firebase returns "null" string value when key is not found
       if (campagneAsString.isEmpty || campagneAsString == "null") return [];
       final json = jsonDecode(campagneAsString) as List;
-      return json
-          .map((e) => RemoteCampagneAccueil.fromJson(e as Map<String, dynamic>))
-          .toList();
+      return json.map((e) => RemoteCampagneAccueil.fromJson(e as Map<String, dynamic>)).toList();
     } catch (e) {
       return [];
     }
@@ -74,9 +64,7 @@ class RemoteConfigRepository {
 
   String? monSuiviDemarchesKoMessage() {
     if (_firebaseRemoteConfig == null) return null;
-    final key = _firebaseRemoteConfig.getString(
-      "mon_suivi_demarches_ko_message",
-    );
+    final key = _firebaseRemoteConfig.getString("mon_suivi_demarches_ko_message");
     if (key.isEmpty || key == "null") return null;
     return key;
   }
@@ -85,18 +73,14 @@ class RemoteConfigRepository {
     if (_firebaseRemoteConfig == null) return null;
     final key = _firebaseRemoteConfig.getString("login_page_message");
     if (key.isEmpty || key == "null") return null;
-    return LoginPageRemoteMessage.fromJson(
-      json.decode(key) as Map<String, dynamic>,
-    );
+    return LoginPageRemoteMessage.fromJson(json.decode(key) as Map<String, dynamic>);
   }
 
   AccueilZenithMessage? accueilZenithMessage() {
     if (_firebaseRemoteConfig == null) return null;
     final key = _firebaseRemoteConfig.getString("zenith_accueil_message_milo");
     if (key.isEmpty || key == "null") return null;
-    return AccueilZenithMessage.fromJson(
-      json.decode(key) as Map<String, dynamic>,
-    );
+    return AccueilZenithMessage.fromJson(json.decode(key) as Map<String, dynamic>);
   }
 
   bool? isDiagorienteEnabled() {
@@ -120,9 +104,7 @@ class RemoteConfigRepository {
 
   String? softUpdateVersion({required bool isAndroid}) {
     if (_firebaseRemoteConfig == null) return null;
-    final key = isAndroid
-        ? 'app_android_soft_update_version'
-        : 'app_ios_soft_update_version';
+    final key = isAndroid ? 'app_android_soft_update_version' : 'app_ios_soft_update_version';
     final value = _firebaseRemoteConfig.getString(key);
     if (value.isEmpty || value == "null") return null;
     return value;
@@ -130,16 +112,11 @@ class RemoteConfigRepository {
 
   FeedbackForFeature? inAppFeedbackForFeature(String feature) {
     if (_firebaseRemoteConfig == null) return null;
-    final String inAppFeedbackAsString = _firebaseRemoteConfig.getString(
-      'in_app_feedback_for_feature',
-    );
+    final String inAppFeedbackAsString = _firebaseRemoteConfig.getString('in_app_feedback_for_feature');
     // Despite Remote config documentation, Firebase returns "null" string value when key is not found
-    if (inAppFeedbackAsString.isEmpty || inAppFeedbackAsString == "null")
-      return null;
+    if (inAppFeedbackAsString.isEmpty || inAppFeedbackAsString == "null") return null;
     final inAppFeedbackAsJson = json.decode(inAppFeedbackAsString);
     final feedbackForFeatureAsJson = inAppFeedbackAsJson[feature];
-    return feedbackForFeatureAsJson != null
-        ? FeedbackForFeature.fromJson(feedbackForFeatureAsJson)
-        : null;
+    return feedbackForFeatureAsJson != null ? FeedbackForFeature.fromJson(feedbackForFeatureAsJson) : null;
   }
 }

--- a/lib/repositories/remote_config_repository.dart
+++ b/lib/repositories/remote_config_repository.dart
@@ -12,13 +12,6 @@ class RemoteConfigRepository {
 
   RemoteConfigRepository(this._firebaseRemoteConfig);
 
-  int? maxLivingTimeInSecondsForMilo() {
-    if (_firebaseRemoteConfig == null) return null;
-
-    final value = _firebaseRemoteConfig.getInt("app_milo_max_living_time_in_seconds");
-    return value > 0 ? value : null;
-  }
-
   int? maxUnauthorizedErrorsBeforeLogout() {
     if (_firebaseRemoteConfig == null) return null;
 

--- a/lib/repositories/remote_config_repository.dart
+++ b/lib/repositories/remote_config_repository.dart
@@ -15,7 +15,9 @@ class RemoteConfigRepository {
   int? maxLivingTimeInSecondsForMilo() {
     if (_firebaseRemoteConfig == null) return null;
 
-    final value = _firebaseRemoteConfig.getInt("app_milo_max_living_time_in_seconds");
+    final value = _firebaseRemoteConfig.getInt(
+      "app_milo_max_living_time_in_seconds",
+    );
     return value > 0 ? value : null;
   }
 
@@ -24,6 +26,16 @@ class RemoteConfigRepository {
 
     final value = _firebaseRemoteConfig.getInt("app_max_401_before_logout");
     return value > 0 ? value : null;
+  }
+
+  int maxRefreshFailuresBeforeLogout() {
+    const defaultMax = 20;
+    if (_firebaseRemoteConfig == null) return defaultMax;
+
+    final value = _firebaseRemoteConfig.getInt(
+      "app_max_refresh_failures_before_logout",
+    );
+    return value > 0 ? value : defaultMax;
   }
 
   int monSuiviPoleEmploiStartDateInMonths() {
@@ -36,7 +48,9 @@ class RemoteConfigRepository {
 
     // millisecond since epoch
     final value = _firebaseRemoteConfig.getInt("campagne_recrutement_date_fin");
-    return value > DateTime.now().millisecondsSinceEpoch ? value.toString() : null;
+    return value > DateTime.now().millisecondsSinceEpoch
+        ? value.toString()
+        : null;
   }
 
   List<RemoteCampagneAccueil> campagnesAccueil() {
@@ -44,11 +58,15 @@ class RemoteConfigRepository {
     try {
       if (_firebaseRemoteConfig == null) return [];
 
-      final campagneAsString = _firebaseRemoteConfig.getString("campagnes_accueil");
+      final campagneAsString = _firebaseRemoteConfig.getString(
+        "campagnes_accueil",
+      );
       // Despite Remote config documentation, Firebase returns "null" string value when key is not found
       if (campagneAsString.isEmpty || campagneAsString == "null") return [];
       final json = jsonDecode(campagneAsString) as List;
-      return json.map((e) => RemoteCampagneAccueil.fromJson(e as Map<String, dynamic>)).toList();
+      return json
+          .map((e) => RemoteCampagneAccueil.fromJson(e as Map<String, dynamic>))
+          .toList();
     } catch (e) {
       return [];
     }
@@ -56,7 +74,9 @@ class RemoteConfigRepository {
 
   String? monSuiviDemarchesKoMessage() {
     if (_firebaseRemoteConfig == null) return null;
-    final key = _firebaseRemoteConfig.getString("mon_suivi_demarches_ko_message");
+    final key = _firebaseRemoteConfig.getString(
+      "mon_suivi_demarches_ko_message",
+    );
     if (key.isEmpty || key == "null") return null;
     return key;
   }
@@ -65,14 +85,18 @@ class RemoteConfigRepository {
     if (_firebaseRemoteConfig == null) return null;
     final key = _firebaseRemoteConfig.getString("login_page_message");
     if (key.isEmpty || key == "null") return null;
-    return LoginPageRemoteMessage.fromJson(json.decode(key) as Map<String, dynamic>);
+    return LoginPageRemoteMessage.fromJson(
+      json.decode(key) as Map<String, dynamic>,
+    );
   }
 
   AccueilZenithMessage? accueilZenithMessage() {
     if (_firebaseRemoteConfig == null) return null;
     final key = _firebaseRemoteConfig.getString("zenith_accueil_message_milo");
     if (key.isEmpty || key == "null") return null;
-    return AccueilZenithMessage.fromJson(json.decode(key) as Map<String, dynamic>);
+    return AccueilZenithMessage.fromJson(
+      json.decode(key) as Map<String, dynamic>,
+    );
   }
 
   bool? isDiagorienteEnabled() {
@@ -96,7 +120,9 @@ class RemoteConfigRepository {
 
   String? softUpdateVersion({required bool isAndroid}) {
     if (_firebaseRemoteConfig == null) return null;
-    final key = isAndroid ? 'app_android_soft_update_version' : 'app_ios_soft_update_version';
+    final key = isAndroid
+        ? 'app_android_soft_update_version'
+        : 'app_ios_soft_update_version';
     final value = _firebaseRemoteConfig.getString(key);
     if (value.isEmpty || value == "null") return null;
     return value;
@@ -104,11 +130,16 @@ class RemoteConfigRepository {
 
   FeedbackForFeature? inAppFeedbackForFeature(String feature) {
     if (_firebaseRemoteConfig == null) return null;
-    final String inAppFeedbackAsString = _firebaseRemoteConfig.getString('in_app_feedback_for_feature');
+    final String inAppFeedbackAsString = _firebaseRemoteConfig.getString(
+      'in_app_feedback_for_feature',
+    );
     // Despite Remote config documentation, Firebase returns "null" string value when key is not found
-    if (inAppFeedbackAsString.isEmpty || inAppFeedbackAsString == "null") return null;
+    if (inAppFeedbackAsString.isEmpty || inAppFeedbackAsString == "null")
+      return null;
     final inAppFeedbackAsJson = json.decode(inAppFeedbackAsString);
     final feedbackForFeatureAsJson = inAppFeedbackAsJson[feature];
-    return feedbackForFeatureAsJson != null ? FeedbackForFeature.fromJson(feedbackForFeatureAsJson) : null;
+    return feedbackForFeatureAsJson != null
+        ? FeedbackForFeature.fromJson(feedbackForFeatureAsJson)
+        : null;
   }
 }

--- a/test/auth/auth_access_token_retriever_test.dart
+++ b/test/auth/auth_access_token_retriever_test.dart
@@ -11,11 +11,15 @@ import '../doubles/spies.dart';
 
 void main() {
   late MockAuthenticator authenticator;
+  late MockRemoteConfigRepository remoteConfig;
+  late FlutterSecureStorageSpy storage;
   late AuthAccessTokenRetriever tokenRetriever;
 
   setUp(() {
     authenticator = MockAuthenticator();
-    tokenRetriever = AuthAccessTokenRetriever(authenticator, MockRemoteConfigRepository(), Lock());
+    remoteConfig = MockRemoteConfigRepository();
+    storage = FlutterSecureStorageSpy(delay: Duration.zero);
+    tokenRetriever = AuthAccessTokenRetriever(authenticator, remoteConfig, storage, Lock());
   });
 
   test("Throws an exception when id token is null", () async {
@@ -43,31 +47,118 @@ void main() {
     expect(await tokenRetriever.accessToken(), "Access token");
   });
 
-  test("Throws an exception when id token is invalid and refresh token returns GENERIC_ERROR", () async {
-    // Given
+  test("Throws WITHOUT logout on a SINGLE GENERIC_ERROR (hoquet transitoire toléré)", () async {
+    // Given : un seul échec ambigu (5xx, réponse incomplète) -> pas de déco
+    final store = StoreSpy();
     when(() => authenticator.idToken()).thenAnswer((_) async => invalidIdToken());
     when(() => authenticator.performRefreshToken()).thenAnswer((_) async => RefreshTokenStatus.GENERIC_ERROR);
+    when(() => remoteConfig.maxRefreshFailuresBeforeLogout()).thenReturn(3);
+    tokenRetriever.setStore(store);
 
     // When-Then
     expect(() async => await tokenRetriever.accessToken(), throwsException);
+    expect(store.dispatchedAction, isNot(isA<RequestLogoutAction>()));
   });
 
-  test("Throws an exception when id token is invalid and refresh token returns USER_NOT_LOGGED_IN", () async {
+  test("Logout après N GENERIC_ERROR consécutifs", () async {
     // Given
+    final store = StoreSpy();
+    when(() => authenticator.idToken()).thenAnswer((_) async => invalidIdToken());
+    when(() => authenticator.performRefreshToken()).thenAnswer((_) async => RefreshTokenStatus.GENERIC_ERROR);
+    when(() => remoteConfig.maxRefreshFailuresBeforeLogout()).thenReturn(2);
+    tokenRetriever.setStore(store);
+
+    // When : 1er échec -> compteur=1, pas de logout
+    try {
+      await tokenRetriever.accessToken();
+    } catch (_) {}
+    expect(store.dispatchedAction, isNot(isA<RequestLogoutAction>()));
+
+    // 2e échec -> compteur=2 -> logout
+    try {
+      await tokenRetriever.accessToken();
+    } catch (_) {}
+    expect(store.dispatchedAction, isA<RequestLogoutAction>());
+  });
+
+  test("Le compteur SURVIT au kill de l'app (persistance via storage)", () async {
+    // Given
+    final store = StoreSpy();
+    when(() => authenticator.idToken()).thenAnswer((_) async => invalidIdToken());
+    when(() => authenticator.performRefreshToken()).thenAnswer((_) async => RefreshTokenStatus.GENERIC_ERROR);
+    when(() => remoteConfig.maxRefreshFailuresBeforeLogout()).thenReturn(2);
+
+    // Session 1 : 1 échec -> compteur=1 (persisté), pas de logout
+    final retriever1 = AuthAccessTokenRetriever(authenticator, remoteConfig, storage, Lock())..setStore(store);
+    try {
+      await retriever1.accessToken();
+    } catch (_) {}
+    expect(store.dispatchedAction, isNot(isA<RequestLogoutAction>()));
+
+    // Kill + relance : NOUVELLE instance, MÊME storage -> le compteur reprend à 1
+    final retriever2 = AuthAccessTokenRetriever(authenticator, remoteConfig, storage, Lock())..setStore(store);
+    try {
+      await retriever2.accessToken();
+    } catch (_) {}
+
+    // Then : 2e échec global -> compteur=2 -> logout (le kill n'a PAS remis à zéro)
+    expect(store.dispatchedAction, isA<RequestLogoutAction>());
+  });
+
+  test("Un refresh réussi remet le compteur à zéro", () async {
+    // Given
+    final store = StoreSpy();
+    when(() => authenticator.idToken()).thenAnswer((_) async => invalidIdToken());
+    when(() => authenticator.accessToken()).thenAnswer((_) async => "Access token");
+    when(() => remoteConfig.maxRefreshFailuresBeforeLogout()).thenReturn(2);
+    tokenRetriever.setStore(store);
+
+    // When : GENERIC (1), puis SUCCESS (reset), puis GENERIC (1) -> jamais 2 d'affilée
+    when(() => authenticator.performRefreshToken()).thenAnswer((_) async => RefreshTokenStatus.GENERIC_ERROR);
+    try {
+      await tokenRetriever.accessToken();
+    } catch (_) {}
+    when(() => authenticator.performRefreshToken()).thenAnswer((_) async => RefreshTokenStatus.SUCCESSFUL);
+    await tokenRetriever.accessToken();
+    when(() => authenticator.performRefreshToken()).thenAnswer((_) async => RefreshTokenStatus.GENERIC_ERROR);
+    try {
+      await tokenRetriever.accessToken();
+    } catch (_) {}
+
+    // Then : le succès a remis le compteur à zéro -> pas de logout
+    expect(store.dispatchedAction, isNot(isA<RequestLogoutAction>()));
+  });
+
+  test("Logout user and throw when id token is invalid and refresh token returns USER_NOT_LOGGED_IN", () async {
+    // Given
+    final store = StoreSpy();
     when(() => authenticator.idToken()).thenAnswer((_) async => invalidIdToken());
     when(() => authenticator.performRefreshToken()).thenAnswer((_) async => RefreshTokenStatus.USER_NOT_LOGGED_IN);
+    tokenRetriever.setStore(store);
 
-    // When-Then
-    expect(() async => await tokenRetriever.accessToken(), throwsException);
+    // When
+    Object? thrown;
+    try {
+      await tokenRetriever.accessToken();
+    } catch (e) {
+      thrown = e;
+    }
+
+    // Then
+    expect(thrown, isException);
+    expect(store.dispatchedAction, isA<RequestLogoutAction>());
   });
 
-  test("Throws an exception when id token is invalid and refresh token returns NETWORK_UNREACHABLE", () async {
-    // Given
+  test("Throws WITHOUT logout when id token is invalid and refresh token returns NETWORK_UNREACHABLE", () async {
+    // Given : hors-ligne transitoire, on garde la session
+    final store = StoreSpy();
     when(() => authenticator.idToken()).thenAnswer((_) async => invalidIdToken());
     when(() => authenticator.performRefreshToken()).thenAnswer((_) async => RefreshTokenStatus.NETWORK_UNREACHABLE);
+    tokenRetriever.setStore(store);
 
     // When-Then
     expect(() async => await tokenRetriever.accessToken(), throwsException);
+    expect(store.dispatchedAction, isNot(isA<RequestLogoutAction>()));
   });
 
   test("Throws an exception when id token is invalid and refresh token returns EXPIRED_REFRESH_TOKEN", () async {

--- a/test/auth/auth_id_token_test.dart
+++ b/test/auth/auth_id_token_test.dart
@@ -8,16 +8,7 @@ void main() {
   final oneSecondBeforeExpiration = expiredIn30Minutes.subtract(Duration(seconds: 16));
   final oneSecondAfterExpiration = expiredIn30Minutes.subtract(Duration(seconds: 14));
 
-  const maxLivingTime5Minutes = 5 * 60;
-  final maxLivingTime = issuedAtTime.add(Duration(minutes: 5));
-  final oneSecondBeforeMaxLivingTime = maxLivingTime.subtract(Duration(seconds: 16));
-  final oneSecondAfterMaxLivingTime = maxLivingTime.subtract(Duration(seconds: 14));
-
-  void assertIsValid({
-    required DateTime now,
-    int? maxLivingTimeInSeconds,
-    required bool expected,
-  }) {
+  void assertIsValid({required DateTime now, required bool expected}) {
     final token = AuthIdToken(
       userId: "",
       lastName: "",
@@ -27,35 +18,14 @@ void main() {
       expiresAt: expiredIn30Minutes.millisecondsSinceEpoch ~/ 1000,
       structure: 'MILO',
     );
-    final isValid = token.isValid(now: now, maxLivingTimeInSeconds: maxLivingTimeInSeconds);
-    expect(isValid, expected);
+    expect(token.isValid(now: now), expected);
   }
 
-  group("without max living time", () {
-    test('is valid return true if token expires in more than 15 seconds', () {
-      assertIsValid(now: oneSecondBeforeExpiration, expected: true);
-    });
-
-    test('is valid return false if token expires in less than 15 seconds', () {
-      assertIsValid(now: oneSecondAfterExpiration, expected: false);
-    });
+  test('is valid returns true if token expires in more than 15 seconds', () {
+    assertIsValid(now: oneSecondBeforeExpiration, expected: true);
   });
 
-  group("with max living time", () {
-    test('is valid return true if token expires in more than 15 seconds and is below max living time', () {
-      assertIsValid(
-        now: oneSecondBeforeMaxLivingTime,
-        maxLivingTimeInSeconds: maxLivingTime5Minutes,
-        expected: true,
-      );
-    });
-
-    test('is valid return false if token expires in more than 15 seconds but is above max living time', () {
-      assertIsValid(
-        now: oneSecondAfterMaxLivingTime,
-        maxLivingTimeInSeconds: maxLivingTime5Minutes,
-        expected: false,
-      );
-    });
+  test('is valid returns false if token expires in less than 15 seconds', () {
+    assertIsValid(now: oneSecondAfterExpiration, expected: false);
   });
 }

--- a/test/auth/authenticator_test.dart
+++ b/test/auth/authenticator_test.dart
@@ -226,14 +226,18 @@ void main() {
       expect(await authenticator.isLoggedIn(), false);
     });
 
-    test('FALSE is returned if user was not logged in', () async {
-      // Given user not logged in
+    test('local idToken is cleared even when refresh token is missing (secure storage desync)', () async {
+      // Given : idToken valide résiduel mais pas de refresh token (désync)
+      await secureStorage.write(key: 'idToken', value: realPassEmploiIdToken);
+      expect(await authenticator.isLoggedIn(), isTrue);
 
       // When
       final result = await authenticator.logout('NOT_LOGIN_USER', LogoutReason.expiredRefreshToken);
 
-      // Then
-      expect(result, isFalse);
+      // Then : sans le fix, logout sortait en false sans effacer l'idToken
+      // -> isLoggedIn restait true -> utilisateur bloqué, incapable de se déco
+      expect(result, isTrue);
+      expect(await authenticator.isLoggedIn(), isFalse);
     });
   });
 

--- a/test/doubles/mocks.dart
+++ b/test/doubles/mocks.dart
@@ -254,6 +254,7 @@ class MockOnboardingRepository extends Mock implements OnboardingRepository {
 
 class MockRemoteConfigRepository extends Mock implements RemoteConfigRepository {
   MockRemoteConfigRepository() {
+    when(() => maxLivingTimeInSecondsForMilo()).thenReturn(null);
     when(() => maxRefreshFailuresBeforeLogout()).thenReturn(20);
     when(() => lastCampagneRecrutementId()).thenReturn(null);
     when(() => monSuiviPoleEmploiStartDateInMonths()).thenReturn(1);

--- a/test/doubles/mocks.dart
+++ b/test/doubles/mocks.dart
@@ -254,7 +254,7 @@ class MockOnboardingRepository extends Mock implements OnboardingRepository {
 
 class MockRemoteConfigRepository extends Mock implements RemoteConfigRepository {
   MockRemoteConfigRepository() {
-    when(() => maxLivingTimeInSecondsForMilo()).thenReturn(null);
+    when(() => maxRefreshFailuresBeforeLogout()).thenReturn(20);
     when(() => lastCampagneRecrutementId()).thenReturn(null);
     when(() => monSuiviPoleEmploiStartDateInMonths()).thenReturn(1);
     when(() => campagnesAccueil()).thenReturn([]);

--- a/test/doubles/mocks.dart
+++ b/test/doubles/mocks.dart
@@ -254,7 +254,6 @@ class MockOnboardingRepository extends Mock implements OnboardingRepository {
 
 class MockRemoteConfigRepository extends Mock implements RemoteConfigRepository {
   MockRemoteConfigRepository() {
-    when(() => maxLivingTimeInSecondsForMilo()).thenReturn(null);
     when(() => maxRefreshFailuresBeforeLogout()).thenReturn(20);
     when(() => lastCampagneRecrutementId()).thenReturn(null);
     when(() => monSuiviPoleEmploiStartDateInMonths()).thenReturn(1);

--- a/test/features/login/post_logout_sign_out_from_firebase_test.dart
+++ b/test/features/login/post_logout_sign_out_from_firebase_test.dart
@@ -23,9 +23,9 @@ void main() {
 
     // When
     await store.dispatch(RequestLogoutAction(LogoutReason.userLogout));
+    await Future.delayed(const Duration(milliseconds: 50));
 
     // Then
-    await untilCalled(() => firebaseAuthWrapper.signOut());
     verify(() => firebaseAuthWrapper.signOut()).called(1);
   });
 }

--- a/test/features/login/post_logout_sign_out_from_firebase_test.dart
+++ b/test/features/login/post_logout_sign_out_from_firebase_test.dart
@@ -25,6 +25,7 @@ void main() {
     await store.dispatch(RequestLogoutAction(LogoutReason.userLogout));
 
     // Then
+    await untilCalled(() => firebaseAuthWrapper.signOut());
     verify(() => firebaseAuthWrapper.signOut()).called(1);
   });
 }

--- a/test/features/tech/crashlytics_middleware_test.dart
+++ b/test/features/tech/crashlytics_middleware_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:pass_emploi_app/crashlytics/crashlytics.dart';
+import 'package:pass_emploi_app/features/login/login_actions.dart';
+import 'package:pass_emploi_app/features/tech/crashlytics_middleware.dart';
+import 'package:pass_emploi_app/redux/app_state.dart';
+import 'package:redux/redux.dart';
+
+class MockCrashlytics extends Mock implements Crashlytics {}
+
+class MockStore extends Mock implements Store<AppState> {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(StackTrace.empty);
+  });
+
+  late MockCrashlytics crashlytics;
+  late MockStore store;
+  late CrashlyticsMiddleware middleware;
+
+  setUp(() {
+    crashlytics = MockCrashlytics();
+    store = MockStore();
+    when(() => store.state).thenReturn(AppState.initialState());
+    middleware = CrashlyticsMiddleware(crashlytics);
+  });
+
+  void dispatch(dynamic action) => middleware.call(store, action, (_) {});
+
+  group('Logout tracking', () {
+    test(
+      'records a non-fatal + custom key for an UNEXPECTED (subi) logout',
+      () {
+        dispatch(RequestLogoutAction(LogoutReason.tooManyRefreshGenericErrors));
+
+        verify(
+          () => crashlytics.setCustomKey(
+            'last_logout_reason',
+            'tooManyRefreshGenericErrors',
+          ),
+        ).called(1);
+        verify(
+          () => crashlytics.recordNonNetworkException(any(), any()),
+        ).called(1);
+      },
+    );
+
+    test(
+      'does NOT record a non-fatal for a voluntary logout (custom key + log only)',
+      () {
+        dispatch(RequestLogoutAction(LogoutReason.userLogout));
+
+        verify(
+          () => crashlytics.setCustomKey('last_logout_reason', 'userLogout'),
+        ).called(1);
+        verifyNever(() => crashlytics.recordNonNetworkException(any(), any()));
+      },
+    );
+  });
+
+  group('Zombie tracking', () {
+    test(
+      'records a zombie non-fatal on the FIRST consecutive refresh failure',
+      () {
+        dispatch(TokenRefreshGenericErrorAction(1));
+
+        verify(
+          () => crashlytics.setCustomKey('consecutive_refresh_failures', '1'),
+        ).called(1);
+        verify(
+          () => crashlytics.recordNonNetworkException(any(), any()),
+        ).called(1);
+      },
+    );
+
+    test(
+      'does NOT record a non-fatal on subsequent failures (only custom key + log)',
+      () {
+        dispatch(TokenRefreshGenericErrorAction(3));
+
+        verify(
+          () => crashlytics.setCustomKey('consecutive_refresh_failures', '3'),
+        ).called(1);
+        verifyNever(() => crashlytics.recordNonNetworkException(any(), any()));
+      },
+    );
+  });
+}


### PR DESCRIPTION
**authenticator.dart**

Avant : quand on déconnecte, le code lisait le refresh token. S'il n'y en avait pas, il s'arrêtait là (return false) sans effacer l'idToken. Or l'app décide « est-ce que je suis connecté ? » en regardant l'idToken. Donc un idToken resté tout seul (désync du stockage) = l'app se croit connectée, la déco ne fait rien → bloqué.

Après : on tente la déco côté serveur si possible, mais on efface toujours les tokens locaux à la fin. Donc la déconnexion réussit toujours → retour au login garanti.

**auth_access_token_retriever.dart**

Quand l'app tente un refresh, si le retour du refresh est un token vide, ça lançait une erreur sans déco → l'app re-tente en boucle, bloquée. Après le fix, on déco si pas de token retourné au refresh.
**Bonus :** sur le commit 3, j'ai traité le GENERIC_ERROR avec un compteur avec d'echec qui logout si t'as l'erreur plus de 20 fois (je soupconne que ça soit ça qui fait que l'utilisateur navigue dans le vide dans l'app)

**Crashlytics** : les pbs 2 loggés : les GENERIC_ERROR consecutifs et le Logout
